### PR TITLE
Add Korean price matching UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,5 @@
-# Compiled class file
-*.class
-
-# Log file
+node_modules
+.next
+out
+.DS_Store
 *.log
-
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
-
-# Kotlin Gradle plugin data, see https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
-.kotlin/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+
+# 가격 매칭 사이트
+
+한국인을 위한 간단한 가격 비교 사이트입니다. Next.js로 제작되었습니다.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+## License
+
+MIT

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+declare module '*.module.css';
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "price-match",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,5 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css'
+import type { Metadata } from 'next'
+import { Noto_Sans_KR } from 'next/font/google'
+
+const noto = Noto_Sans_KR({ subsets: ['latin'] })
+
+export const metadata: Metadata = {
+  title: '가격 매칭',
+  description: '온라인 스토어 가격 비교',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ko">
+      <body className={noto.className}>{children}</body>
+    </html>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Result {
+  store: string
+  price: string
+}
+
+export default function Home() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<Result[] | null>(null)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    // 예시 데이터. 실제 서비스에서는 API 호출을 통해 가져옵니다.
+    setResults([
+      { store: '스토어A', price: '₩990,000' },
+      { store: '스토어B', price: '₩995,000' },
+      { store: '스토어C', price: '₩1,000,000' },
+    ])
+  }
+
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1>가격 매칭</h1>
+      <p>상품 가격을 비교해 보세요.</p>
+      <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="상품명을 입력하세요"
+        />
+        <button type="submit">검색</button>
+      </form>
+      {results && (
+        <table>
+          <thead>
+            <tr>
+              <th>스토어</th>
+              <th>가격</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map(({ store, price }) => (
+              <tr key={store}>
+                <td>{store}</td>
+                <td>{price}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </main>
+  )
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- update README for Korean users
- localize layout and add Korean font
- implement basic price matching interface in Korean

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68721b1b6dc4832c94a14785d842bf9b